### PR TITLE
vim API: global XKeyboard variable my throw

### DIFF
--- a/XKbSwitchApi.cpp
+++ b/XKbSwitchApi.cpp
@@ -46,7 +46,6 @@ namespace
 
     }  xkb;
 
-    //XKeyboard     xkb;
     string_vector  symNames;
 
     string_vector &  getSymNames( void )


### PR DESCRIPTION
global XKeyboard variable xkb will throw uncatchable exception if X is
not available. This will make vim SIGSEGV: see this issue:
http://github.com/lyokha/vim-xkbswitch/issues/5. In this commit a
wrapper class was introduced that will catch exceptions from XKeyboard()
