### PR TITLE
Allow using -p and -n arguments together

### DIFF
--- a/XKbSwitch.cpp
+++ b/XKbSwitch.cpp
@@ -112,7 +112,7 @@ int main( int argc, char* argv[] )
 			}
 		}
 
-		if(m_list || m_lwait || !newgrp.empty() || m_next)
+		if(m_list || m_lwait || !newgrp.empty())
 			CHECK_MSG(m_cnt==1, "Invalid flag combination. Try --help.");
 
 		// Default action


### PR DESCRIPTION
In the some cases the user might want to change to the next layout, and afterwards print it (so he'll know in which layout he's standing...)