### PR TITLE
calling XFlush() instead of get_group()

### DIFF
--- a/XKeyboard.cpp
+++ b/XKeyboard.cpp
@@ -128,7 +128,7 @@ void XKeyboard::set_group(int groupNum)
 {
   Bool result = XkbLockGroup(_display, _deviceId, groupNum);
   CHECK(result == True);
-  (void) get_group();
+  XFlush(_display);
 }
 
 int XKeyboard::get_group() const


### PR DESCRIPTION
is lightweight and straightforward (see details in my comment for #18)