### PR TITLE
do not let xkb-switch crash when $DISPLAY is not set

### DIFF
--- a/XKeyboard.cpp
+++ b/XKeyboard.cpp
@@ -25,7 +25,7 @@
 namespace kb {
 
 XKeyboard::XKeyboard()
-  : _display(0), _deviceId(XkbUseCoreKbd)
+  : _display(0), _deviceId(XkbUseCoreKbd), _kbdDescPtr(0)
 {
 }
 
@@ -76,7 +76,9 @@ XKeyboard::~XKeyboard()
   if(_kbdDescPtr!=NULL)
     XkbFreeKeyboard(_kbdDescPtr, 0, True);
 
-  XCloseDisplay(_display);
+  if (_display!=NULL) {
+      XCloseDisplay(_display);
+  }
 }
 
 


### PR DESCRIPTION
(see also https://github.com/lyokha/vim-xkbswitch/pull/30).

... why it crashes ... XKeyboard object is defined locally in a
try/catch block, then xkb.open_display() is called which produces an
exception, but the exception won't reach a catch-clause because faulty
XKeyboard destructor occurs earlier (at the exit from the try-clause)
which makes xkb-switch sigsegv. This must fix the library part too.

(You can test it by ``xkb-switch -l`` in a virtual Linux console before
and after the fix applied).