### PR TITLE
Prevent memory leaks

### DIFF
--- a/src/XKeyboard.cpp
+++ b/src/XKeyboard.cpp
@@ -34,7 +34,7 @@ void XKeyboard::open_display()
 
   XkbIgnoreExtension(False);
 
-  char* displayName = strdup("");
+  char* displayName = strdup(""); // allocates memory for string!
   int eventCode;
   int errorReturn;
   int major = XkbMajorVersion;
@@ -43,6 +43,7 @@ void XKeyboard::open_display()
 
   _display = XkbOpenDisplay(displayName, &eventCode, &errorReturn, &major,
       &minor, &reasonReturn);
+  free(displayName);
   switch (reasonReturn) {
     case XkbOD_BadLibraryVersion:
       throw X11Exception("Bad XKB library version.");

--- a/src/XKeyboard.cpp
+++ b/src/XKeyboard.cpp
@@ -109,6 +109,7 @@ void XKeyboard::build_layout(string_vector& out)
   Bool bret;
 
   bret = XkbRF_GetNamesProp(_display, &tmp, &vdr._it);
+  free(tmp);  // return memory allocated by XkbRF_GetNamesProp
   CHECK_MSG(bret==True, "Failed to get keyboard properties");
 
   std::istringstream layout(vdr._it.layout ? vdr._it.layout : "us");


### PR DESCRIPTION
Hello, Sergei.
Think I found some places in `XKeyboard.cpp` that are making memory leaks. `valgrind` tool helped to do it.

1. At line 37: at the first look, `displayName` gets a value of empty string, but function `strdup()` allocates memory for it, using `malloc()`.
2. Line 111. Function `XkbRf_getNamesProp()` not only fills up `vdr`, but also inits `tmp` with some data, also allocating some memory. I think, that's why issue #31 still opened.

Performed tests: inside of `build` directory, with binaries compiled, ran command

~~~sh
valgrind --tool=memcheck --leak-check=full ./xkb-switch
~~~

Before changes it printed:

~~~text
==12360== Memcheck, a memory error detector
==12360== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==12360== Using Valgrind-3.9.0 and LibVEX; rerun with -h for copyright info
==12360== Command: ./xkb-switch
==12360== 
==12360== Warning: client switching stacks?  SP change: 0xbedd2a40 --> 0x4022f9c
==12360==          to suppress, use: --max-stackframe=1160054108 or greater
==12360== Warning: client switching stacks?  SP change: 0x4022f9c --> 0xbedd2a40
==12360==          to suppress, use: --max-stackframe=1160054108 or greater
us
==12360== 
==12360== HEAP SUMMARY:
==12360==     in use at exit: 7 bytes in 2 blocks
==12360==   total heap usage: 80 allocs, 78 frees, 85,740 bytes allocated
==12360== 
==12360== 1 bytes in 1 blocks are definitely lost in loss record 1 of 2
==12360==    at 0x402AD88: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==12360==    by 0x43BB829: strdup (in /lib/i686/libc-2.19.so)
==12360==    by 0x403B4CD: kb::XKeyboard::open_display() (in /home/alexandr/Projects/cpp/xkb-switch/build/libxkbswitch.so.1.5.3)
==12360==    by 0x804B41A: main (in /home/alexandr/Projects/cpp/xkb-switch/build/xkb-switch)
==12360== 
==12360== 6 bytes in 1 blocks are definitely lost in loss record 2 of 2
==12360==    at 0x402AD88: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==12360==    by 0x43BB829: strdup (in /lib/i686/libc-2.19.so)
==12360==    by 0x41BB53A: XkbRF_GetNamesProp (in /usr/lib/libxkbfile.so.1.0.2)
==12360==    by 0x403B9CC: kb::XKeyboard::build_layout(std::vector<std::string, std::allocator<std::string> >&) (in /home/alexandr/Projects/cpp/xkb-switch/build/libxkbswitch.so.1.5.3)
==12360==    by 0x804B4DD: main (in /home/alexandr/Projects/cpp/xkb-switch/build/xkb-switch)
==12360== 
==12360== LEAK SUMMARY:
==12360==    definitely lost: 7 bytes in 2 blocks
==12360==    indirectly lost: 0 bytes in 0 blocks
==12360==      possibly lost: 0 bytes in 0 blocks
==12360==    still reachable: 0 bytes in 0 blocks
==12360==         suppressed: 0 bytes in 0 blocks
==12360== 
==12360== For counts of detected and suppressed errors, rerun with: -v
==12360== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
~~~

After changes output is:

~~~text
==13684== Memcheck, a memory error detector
==13684== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==13684== Using Valgrind-3.9.0 and LibVEX; rerun with -h for copyright info
==13684== Command: ./xkb-switch
==13684== 
==13684== Warning: client switching stacks?  SP change: 0xbed79a40 --> 0x4022f9c
==13684==          to suppress, use: --max-stackframe=1160418652 or greater
==13684== Warning: client switching stacks?  SP change: 0x4022f9c --> 0xbed79a40
==13684==          to suppress, use: --max-stackframe=1160418652 or greater
us
==13684== 
==13684== HEAP SUMMARY:
==13684==     in use at exit: 0 bytes in 0 blocks
==13684==   total heap usage: 80 allocs, 80 frees, 85,740 bytes allocated
==13684== 
==13684== All heap blocks were freed -- no leaks are possible
==13684== 
==13684== For counts of detected and suppressed errors, rerun with: -v
==13684== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
~~~
