### PR TITLE
The API library should not print on the terminal

### DIFF
--- a/src/XKbSwitchApi.cpp
+++ b/src/XKbSwitchApi.cpp
@@ -38,7 +38,7 @@ namespace
 
                 try
                 {
-                    xkb = new XKeyboard((size_t)(-1));
+                    xkb = new XKeyboard(0);
                     xkb->open_display();
                 }
                 catch( ... )


### PR DESCRIPTION
Switched verbosity level from maximum `(size_t)(-1)` to `0`.
See also the original issue lyokha/vim-xkbswitch#50.